### PR TITLE
Add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Hands-on workshops covering Git, GitHub, and collaboration best practices",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Adds a new "GitHub Skills" extracurricular activity announced in issue #6. This is time-sensitive so it includes a schedule, capacity, and an empty participant list.